### PR TITLE
Add required environment variable to the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUSTTARGET: ${{ matrix.target }}
           EXTRA_FILES: "README.md LICENSE"
+          SRC_DIR: ./
 ```
 
 _Many target triples do not work, I am working on adding more support_


### PR DESCRIPTION
I noticed that `SRC_DIR` is a required environment variable.